### PR TITLE
Version 2.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 node_modules
 
 npm-debug.log
+*.tgz

--- a/.npmignore
+++ b/.npmignore
@@ -6,6 +6,7 @@ lib-cov
 *.out
 *.pid
 *.gz
+*.tgz
 
 pids
 logs
@@ -13,3 +14,5 @@ results
 
 npm-debug.log
 node_modules
+.travis.yml
+test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - "0.10"
+  - "lts/*"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2013-2014 NOOK Media, LLC
+Copyright (c) 2013-2014 NOOK Media, LLC and (c) 2018 Donavon West
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.md
+++ b/README.md
@@ -1,39 +1,78 @@
 json_
 =====
 
-[![Build Status](https://travis-ci.org/YuzuJS/json_.png)](https://travis-ci.org/YuzuJS/json_)
+[![Build Status](https://travis-ci.org/donavon/json_.svg?branch=master)](https://travis-ci.org/donavon/json_) [![npm version](https://img.shields.io/npm/v/json_.svg)](https://www.npmjs.com/package/json_)
 
 Converts camelCase JavaScript objects to JSON snake_case and vise versa. This is a direct replacement for the built-in JSON object. In fact, this simply wraps the built-in JSON object. Very handy when your back_end APIs are not build using Node.js.
+It also supports converting a `fetch` response stream into a camelCased object.
 
 ### First, get the package
-json_ has zero dependencies and comes with AMD and CommonJS module boilerplate. If the last sentence meant nothing to you then simply drop the following into your page:
 
-    <script src="https://raw.github.com/NobleJS/json_/master/lib/json_.js"></script>
-
-```
+Install json_ and include it in your build.
+```bash
 npm install json_ --save
+```
+
+Then import it like this.
+```js
+import JSON_ from 'json_';
 ```
 
 ### Example
 
-``` javascript
-var JSON_ = require("json_");
-var example = {
+``` js
+const example = {
     firstName: "John",
     lastName: "Doe",
     isbn10: "1234567890"
 };
 
-console.log(JSON_.stringify(example)); // "{"first_name":"John","last_name":"Doe", "isbn_10": "1234567890"}"
+console.log(JSON_.stringify(example));
+// {"first_name":"John","last_name":"Doe", "isbn_10": "1234567890"}
 ```
 
 And vise versa.
 
-``` javascript
-var JSON_ = require("json_");
-var str = '{"ultimate_answer": 42}';
+``` js
+import JSON_ from 'json_';
+const str = '{"ultimate_answer": 42}';
 
-console.log(JSON_.parse(str)); // Object {ultimateAnswer: 42}
+console.log(JSON_.parse(str));
+// {ultimateAnswer: 42}
+```
+
+### Using with `fetch`
+
+You can use `json_` directly with the JavaScript `fetch` API to convert
+the `Response` into an `Object` with snakeCase.
+
+Let's say you have a function that returns snake_case weather data, something like this.
+
+```js
+const fetchWeather = zip => (
+  fetch(`${weatherUrl}?zip=${zip}`)
+    .then(res => res.json())
+);
+
+const data = await fetchWeather('10285');
+console.log(data);
+// {current_temp: 85, reporting_station: 'New York, NY'}
+```
+
+You can easily convert the resolved object to camelCase by replacing the call to `Response.json()`
+to a call to `JSON_.parse(Response)`, like this.
+
+```js
+import JSON_ from 'json_';
+
+const fetchWeather = zip => (
+  fetch(`${weatherUrl}?zip=${zip}`)
+    .then(JSON_.parse)
+);
+
+const data = await fetchWeather('10285');
+console.log(data);
+// {currentTemp: 85, reportingStation: 'New York, NY'}
 ```
 
 ### Tests!

--- a/lib/json_.js
+++ b/lib/json_.js
@@ -1,5 +1,5 @@
 ﻿/* jshint unused:vars, sub:true */
-/* global window, define, module */
+/* global window, module */
 (function () {
     "use strict";
 
@@ -21,9 +21,12 @@
         });
     }
 
-    JSON_.parse = function parse(text, reviver) {
-        text = text.replace(/"([^"]*)"\s*:/g, snakeToCamelCase);
-        return JSON.parse(text, reviver);
+    JSON_.parse = function parse(responseOrText, reviver) {
+        if (typeof responseOrText === 'string') {
+            var text = responseOrText.replace(/"([^"]*)"\s*:/g, snakeToCamelCase);
+            return JSON.parse(text, reviver);
+        }
+        return responseOrText.text().then(parse); // Assume text is a Response object from fetch.
     };
 
     JSON_.stringify = function stringify(value, replacer, space) {
@@ -32,11 +35,9 @@
     };
 
     // Export to popular environments boilerplate.
-    if (typeof define === "function" && define.amd) {
-        define(JSON_);
-    } else if (typeof module !== "undefined" && module.exports) {
+    if (typeof module !== "undefined" && module.exports) {
         module.exports = JSON_;
     } else {
         window["JSON_"] = JSON_;
     }
-}());
+})();

--- a/package.json
+++ b/package.json
@@ -1,34 +1,23 @@
 {
   "name": "json_",
   "description": "Converts camelCase JavaScript objects to JSON snake_case and vise versa.",
-  "version": "1.0.0",
-  "homepage": "https://github.com/YuzuJS/json_",
-  "author": {
-    "name": "YuzuJS"
-  },
+  "version": "2.0.0",
+  "homepage": "https://github.com/donavon/json_",
+  "author": "Donavon West <email@donavon.com> (http://donavon.com)",
   "keywords": [
     "JSON",
     "snakecase",
-    "camelcase"
-  ],
-  "contributors": [
-    {
-      "name": "Donavon West",
-      "email": "email@donavon.com",
-      "url": "http://donavon.com"
-    }
+    "camelcase",
+    "fetch"
   ],
   "dependencies": {},
-  "license": {
-    "type": "MIT",
-    "url": "http://github.com/YuzuJS/json_/raw/master/LICENSE"
-  },
+  "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git://github.com/YuzuJS/json_.git"
+    "url": "git://github.com/donavon/json_.git"
   },
   "bugs": {
-    "url": "http://github.com/YuzuJS/json_/issues"
+    "url": "http://github.com/donavon/json_/issues"
   },
   "scripts": {
     "test": "mocha"
@@ -37,7 +26,7 @@
   "readmeFilename": "README.md",
   "devDependencies": {
     "chai": "~1.9.2",
-    "sinon": "~1.11.1",
-    "mocha": "~2.0.1"
+    "mocha": "~2.0.1",
+    "sinon": "~1.11.1"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,8 +1,14 @@
 var assert = require("assert");
 var JSON_ = require("../.");
 
+var responseStub = {
+    text: function() {
+        return Promise.resolve('{ "foo_bar": 1 }');
+    }
+};
+
 describe('JSON_', function(){
-    describe('parse', function(){
+    describe('parse (passing a string)', function (){
         it('should return camelCase property names given snake_case JSON', function (){
             var data;
             data = JSON_.parse('{"first_name": ""}');
@@ -15,7 +21,18 @@ describe('JSON_', function(){
             assert.equal(Object.keys(data)[0], "scoresA1");
         });
     });
-    describe('stringify', function(){
+    describe('parse (passing a Response)', function (){
+        it('should return a promise', function (){
+            assert.equal(JSON_.parse(responseStub)  instanceof Promise, true);
+        });
+        it('that resolves with a camelCased JS object', function (done){
+            JSON_.parse(responseStub).then(function (obj) {
+                assert.equal(JSON.stringify(obj), JSON.stringify({ fooBar: 1 }));
+                done();
+            });
+        });
+    });
+    describe('stringify', function (){
         it('should return snake_case JSON given an object with camelCase property names', function (){
             var data;
             data = JSON_.stringify({firstName: ""});


### PR DESCRIPTION
* `JSON_parse()` now supports taking either a string or a `Response` object from `fetch`.
    ```js
    fetch(url)
      .then(JSON_.parse)  // returns a camelCased JS object
    ```

* Drop support for AMD and `window.JSON_`

* Adds tests for new functionality